### PR TITLE
Fixed minor grammatical issue with error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ MyClass.new.sum(1, 2)
 #=> 3
 
 MyClass.new.sum(1, 'string')
-#=> Rubype::ArgumentTypeError: Expected MyClass#sum's 2th argument to be Numeric but got "string" instead
+#=> Rubype::ArgumentTypeError: Expected MyClass#sum's 2nd argument to be Numeric but got "string" instead
 
 MyClass.new.wrong_sum(1, 2)
 #=> Rubype::ReturnTypeError: Expected MyClass#wrong_sum to return Numeric but got "string" instead
@@ -75,7 +75,7 @@ MyClass.new.sum('1', 2)
 #=> 3
 
 MyClass.new.sum(:has_no_to_i, 2)
-#=> Rubype::ArgumentTypeError: Expected MyClass#sum's 1th argument to have method #to_i but got :has_no_to_i instead
+#=> Rubype::ArgumentTypeError: Expected MyClass#sum's 1st argument to have method #to_i but got :has_no_to_i instead
 
 
 # ex3: You can use Any class, if you want
@@ -90,7 +90,7 @@ People.new.marry(People.new)
 #=> no error
 
 People.new.marry('non people')
-#=> Rubype::ArgumentTypeError: Expected People#marry's 1th argument to be People but got "non people" instead
+#=> Rubype::ArgumentTypeError: Expected People#marry's 1st argument to be People but got "non people" instead
 
 ```
 

--- a/lib/rubype.rb
+++ b/lib/rubype.rb
@@ -1,3 +1,5 @@
+require 'rubype/ordinal'
+
 # Builtin Contracts
 class  Any;     end
 module Boolean; end
@@ -28,12 +30,12 @@ class Method
       methods_hash[name]
     end
   end
-  
+
   # @return [Array<Class, Symbol>]: [ArgInfo_1, ArgInfo_2, ... ArgInfo_n]
   def arg_types
     type_info.first.first if type_info
   end
-  
+
   # @return [Class, Symbol]: RtnInfo
   def return_type
     type_info.first.last if type_info
@@ -83,10 +85,10 @@ module Rubype
           case type_check(arg, type_info)
           when :need_correct_class
             raise ArgumentTypeError,
-              "Expected #{meth_caller.class}##{meth}'s #{i}th argument to be #{type_info} but got #{arg.inspect} instead"
+              "Expected #{meth_caller.class}##{meth}'s #{i}#{ordinal(i)} argument to be #{type_info} but got #{arg.inspect} instead"
           when :need_correct_method
             raise ArgumentTypeError,
-              "Expected #{meth_caller.class}##{meth}'s #{i}th argument to have method ##{type_info} but got #{arg.inspect} instead"
+              "Expected #{meth_caller.class}##{meth}'s #{i}#{ordinal(i)} argument to have method ##{type_info} but got #{arg.inspect} instead"
           end
         end
       end

--- a/lib/rubype/ordinal.rb
+++ b/lib/rubype/ordinal.rb
@@ -1,0 +1,15 @@
+# Borrowed from ActiveSupport::Inflector
+def ordinal(number)
+  abs_number = number.to_i.abs
+
+  if (11..13).include?(abs_number % 100)
+    "th"
+  else
+    case abs_number % 10
+      when 1; "st"
+      when 2; "nd"
+      when 3; "rd"
+      else    "th"
+    end
+  end
+end

--- a/test/test_rubype.rb
+++ b/test/test_rubype.rb
@@ -106,7 +106,7 @@ class TestRubype < MiniTest::Unit::TestCase
     assert_equal err.message, "Expected MyClass#test_mth to return String but got nil instead"
 
     err = assert_raises(Rubype::ArgumentTypeError) { meth.(1,'2') }
-    assert_equal err.message, "Expected MyClass#test_mth's 2th argument to be Numeric but got \"2\" instead"
+    assert_equal err.message, "Expected MyClass#test_mth's 2nd argument to be Numeric but got \"2\" instead"
   end
 
   private


### PR DESCRIPTION
A very minor issue, but I spotted that "th" is used for all numbers in error messages, e.g. 1th, 2th, 3th etc. when they should be 1st, 2nd, 3rd, etc.

The ordinal function has been borrowed from ActiveSupport, this might not necessarily be the best way to go about this though.