### PR TITLE
Idea for some syntactic sugar

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,20 @@ def sum(x, y)
 end
 typesig :sum, [Numeric, Numeric] => String
 
+# This type definition can also be written like this:
+
+require 'rubype/syntactic_sugar'
+[Numeric, Numeric, String] > def sum(x, y)
+  (x + y).to_s
+end
+
+
 # Assert first arg has method #to_i
 def sum(x, y)
   x.to_i + y
 end
 typesig :sum, [:to_i, Numeric] => Numeric
 ```
-
 
 This gem brings you advantage of type without changing existing code's behavior.
 

--- a/lib/rubype/syntactic_sugar.rb
+++ b/lib/rubype/syntactic_sugar.rb
@@ -1,0 +1,20 @@
+require 'binding_of_caller'
+
+class Array
+  def >(*args)
+    args_match = args.length == 1 && args.first.kind_of?(Symbol)
+    self_matches = length > 0 && all? { |e| e.kind_of?(Class) }
+
+    if args_match && self_matches
+      return_type = self.last
+      call_string = "typesig :#{args.first}, [#{self[0...-1].map(&:name).join(', ')}] => #{return_type}"
+      binding.of_caller(1).eval(call_string)
+    else
+      if !args_match
+        raise "You must pass a Symbol as the only argument to a type definition!"
+      else
+        raise "Wrong type definition #{self}"
+      end
+    end
+  end
+end

--- a/rubype.gemspec
+++ b/rubype.gemspec
@@ -20,6 +20,8 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.0.0"
 
+  spec.add_runtime_dependency "binding_of_caller", "~> 0.7.2"
+
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "minitest"

--- a/test/minitest_helper.rb
+++ b/test/minitest_helper.rb
@@ -1,4 +1,5 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'rubype'
+require 'rubype/syntactic_sugar'
 require 'pry'
 require 'minitest/autorun'


### PR DESCRIPTION
Hey, this is more or less a very hacky spike of making the type definition a little more "natural".

I hope this inspires some more clever people than me to come up with an idea for syntax that makes the extra call to `typesig` after a method definition less painful.

My solution currently looks like this:

``` ruby
require 'rubype/syntactic_sugar'
[Numeric, Numeric, String] > def sum(x, y)
  (x + y).to_s
end
```

and out of pure laziness it only supports classes, not your symbol-method-name notation.

What do you folks think? Was fun to hack on this :) Keep up the good work!
