### PR TITLE
Fix Minitest warning and add vendor to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 *.o
 *.a
 mkmf.log
+/vendor/

--- a/test/test_rubype.rb
+++ b/test/test_rubype.rb
@@ -4,7 +4,7 @@ class TypePair
     "#{last_arg_type} => #{rtn_type}"
   end
 end
-class TestRubype < MiniTest::Unit::TestCase
+class TestRubype < Minitest::Test
   def setup
     @string  = 'str'
     @numeric = 1


### PR DESCRIPTION
MiniTest::Unit::TestCase is now Minitest::Test, let's rename it to fix the warning.

`$ bundle install --path vendor/bundle` creates vendor folder. It is displayed in git status. Also zsh can be annoying considering that repository was changed. Let's solve it by adding vendor folder to gitignore.