### PR TITLE
separate core extensions into an extra file & make ordinal a non-kernel method

### DIFF
--- a/lib/rubype.rb
+++ b/lib/rubype.rb
@@ -1,17 +1,4 @@
-require 'rubype/ordinal'
-# === Rubype core === #
-class Module
-  private
-    def __rubype__
-      prepend (@__rubype__ = Module.new) unless @__rubype__
-      @__rubype__
-    end
-
-    def typesig(meth, type_info_hash)
-      ::Rubype.define_typed_method(self, meth, type_info_hash, __rubype__)
-      self
-    end
-end
+require_relative 'rubype/version'
 
 module Rubype
   @@typed_method_info = Hash.new({})
@@ -68,29 +55,21 @@ Actual:   #{actual.inspect}
 #{caller_trace.join("\n")}
         ERROR_MES
       end
+
+      # Borrowed from ActiveSupport::Inflector
+      def ordinal(number)
+        if (11..13).include?(number % 100)
+          "th"
+        else
+          case number % 10
+            when 1; "st"
+            when 2; "nd"
+            when 3; "rd"
+            else    "th"
+          end
+        end
+      end
   end
 end
-# === end (only 73 lines :D)=== #
 
-# Builtin Contracts
-module Boolean; end
-TrueClass.send(:include, Boolean)
-FalseClass.send(:include, Boolean)
-Any = BasicObject
-
-class Method
-  def type_info
-    Rubype.typed_method_info[owner][name]
-  end
-  typesig :type_info, [] => Hash
-
-  def arg_types
-    type_info.first.first if type_info
-  end
-  typesig :arg_types, [] => Array
-
-  def return_type
-    type_info.first.last if type_info
-  end
-  typesig :arg_types, [] => Any
-end
+require_relative 'rubype/core_ext'

--- a/lib/rubype/core_ext.rb
+++ b/lib/rubype/core_ext.rb
@@ -1,0 +1,35 @@
+module Boolean; end
+TrueClass.send(:include, Boolean)
+FalseClass.send(:include, Boolean)
+Any = BasicObject
+
+class Module
+  private
+
+  def __rubype__
+    prepend (@__rubype__ = Module.new) unless @__rubype__
+    @__rubype__
+  end
+
+  def typesig(meth, type_info_hash)
+    ::Rubype.define_typed_method(self, meth, type_info_hash, __rubype__)
+    self
+  end
+end
+
+class Method
+  def type_info
+    Rubype.typed_method_info[owner][name]
+  end
+  typesig :type_info, [] => Hash
+
+  def arg_types
+    type_info.first.first if type_info
+  end
+  typesig :arg_types, [] => Array
+
+  def return_type
+    type_info.first.last if type_info
+  end
+  typesig :arg_types, [] => Any
+end


### PR DESCRIPTION
This is a suggestion to put core extensions into an extra file, to ease code reading.

It also:
- changes ordinal to a non-core extension method
- always requires rubype/version