### PR TITLE
Extract Contract class

### DIFF
--- a/ext/rubype/rubype.c
+++ b/ext/rubype/rubype.c
@@ -1,9 +1,11 @@
 #include "rubype.h"
 
-VALUE rb_mRubype, rb_eRubypeArgumentTypeError, rb_eRubypeReturnTypeError, rb_eInvalidTypesigError;
+VALUE rb_mRubype, rb_cContract, rb_eRubypeArgumentTypeError, rb_eRubypeReturnTypeError, rb_eInvalidTypesigError;
+
 
 #define STR2SYM(x) ID2SYM(rb_intern(x))
-static ID id_is_a_p, id_to_s, id_plus;
+static ID id_is_a_p, id_to_s, id_plus, id_meth, id_owner, id_arg_types, id_rtn_type;
+
 #define f_boolcast(x) ((x) ? Qtrue : Qfalse)
 
 int unmatch_type_p(VALUE obj, VALUE type_info)
@@ -56,11 +58,18 @@ test(VALUE rubype, VALUE obj)
   return str;
 }
 static VALUE
-rb_rubype_assert_args_type(VALUE rubype, VALUE meth_caller, VALUE meth, VALUE args, VALUE type_infos, VALUE caller_trace)
+rb_rubype_assert_args_type(VALUE self, VALUE rubype, VALUE args)
 {
   int i;
-  VALUE arg, type_info, error_mes;
+  VALUE arg, type_info;
   VALUE target;
+  VALUE meth_caller, meth, type_infos;
+  meth_caller = rb_ivar_get(self, id_owner);
+  meth = rb_ivar_get(self, id_meth);
+  type_infos = rb_ivar_get(self, id_arg_types);
+
+  Check_Type(meth, T_SYMBOL);
+  Check_Type(type_infos, T_ARRAY);
 
   for (i=0; i<RARRAY_LEN(args); i++) {
     arg       = rb_ary_entry(args, i);
@@ -77,9 +86,16 @@ rb_rubype_assert_args_type(VALUE rubype, VALUE meth_caller, VALUE meth, VALUE ar
 }
 
 static VALUE
-rb_rubype_assert_rtn_type(VALUE rubype, VALUE meth_caller, VALUE meth, VALUE rtn, VALUE type_info, VALUE caller_trace)
+rb_rubype_assert_rtn_type(VALUE self, VALUE rubype, VALUE rtn)
 {
   VALUE target;
+  VALUE meth_caller, meth, type_info;
+  meth_caller = rb_ivar_get(self, id_owner);
+  meth = rb_ivar_get(self, id_meth);
+  type_info = rb_ivar_get(self, id_rtn_type);
+
+  Check_Type(meth, T_SYMBOL);
+
   if (unmatch_type_p(rtn, type_info)){
     target = rb_str_new2("");
     rb_str_catf(target, "%"PRIsVALUE"#%"PRIsVALUE"'s return", meth_caller, meth);
@@ -89,16 +105,31 @@ rb_rubype_assert_rtn_type(VALUE rubype, VALUE meth_caller, VALUE meth, VALUE rtn
 }
 
 void
+Init_contract(void)
+{
+  rb_cContract = rb_define_class_under(rb_mRubype, "Contract", rb_cObject);
+  rb_define_method(rb_cContract, "assert_args_type", rb_rubype_assert_args_type, 2);
+  rb_define_method(rb_cContract, "assert_rtn_type", rb_rubype_assert_rtn_type, 2);
+
+  id_meth = rb_intern("@meth");
+  id_owner = rb_intern("@owner");
+  id_arg_types = rb_intern("@arg_types");
+  id_rtn_type = rb_intern("@rtn_type");
+}
+
+void
 Init_rubype(void)
 {
   id_is_a_p = rb_intern_const("is_a?");
   id_to_s = rb_intern_const("to_s");
   id_plus = rb_intern_const("+");
   rb_mRubype  = rb_define_module("Rubype");
+
+
   rb_eRubypeArgumentTypeError = rb_define_class_under(rb_mRubype, "ArgumentTypeError", rb_eTypeError);
   rb_eRubypeReturnTypeError = rb_define_class_under(rb_mRubype, "ReturnTypeError", rb_eTypeError);
   rb_eInvalidTypesigError = rb_define_class_under(rb_mRubype, "InvalidTypesigError", rb_eTypeError);
-  rb_define_singleton_method(rb_mRubype, "assert_args_type", rb_rubype_assert_args_type, 5);
-  rb_define_singleton_method(rb_mRubype, "assert_rtn_type", rb_rubype_assert_rtn_type, 5);
   rb_define_singleton_method(rb_mRubype, "test", test, 1);
+
+  Init_contract();
 }

--- a/lib/rubype.rb
+++ b/lib/rubype.rb
@@ -1,6 +1,5 @@
 require_relative 'rubype/version'
 require_relative 'rubype/contract'
-require 'rubype/rubype'
 
 module Rubype
   module TypeInfo; end
@@ -16,7 +15,7 @@ module Rubype
       @@typed_method[owner][meth] = contract
       method_visibility = get_method_visibility(owner, meth)
       __rubype__.send(:define_method, meth) do |*args, &block|
-        contract.assert_arg_types(self, args)
+        contract.assert_args_type(self, args)
         super(*args, &block)
           .tap { |rtn| contract.assert_rtn_type(self, rtn) }
       end

--- a/lib/rubype.rb
+++ b/lib/rubype.rb
@@ -5,14 +5,14 @@ module Rubype
   module TypeInfo; end
   Module.send(:include, TypeInfo)
   Symbol.send(:include, TypeInfo)
-  @@typed_method = Hash.new({})
+  @@typed_methods = Hash.new({})
 
   class << self
     def define_typed_method(owner, meth, type_info_hash, __rubype__)
       raise InvalidTypesigError unless valid_type_info_hash?(type_info_hash)
       arg_types, rtn_type = *type_info_hash.first
       contract = Contract.new(arg_types, rtn_type, owner, meth)
-      @@typed_method[owner][meth] = contract
+      @@typed_methods[owner][meth] = contract
       method_visibility = get_method_visibility(owner, meth)
       __rubype__.send(:define_method, meth) do |*args, &block|
         contract.assert_args_type(self, args)
@@ -33,8 +33,8 @@ module Rubype
       end
     end
 
-    def typed_method
-      @@typed_method
+    def typed_methods
+      @@typed_methods
     end
 
     private

--- a/lib/rubype.rb
+++ b/lib/rubype.rb
@@ -1,24 +1,24 @@
 require_relative 'rubype/version'
-require_relative 'rubype/ordinalize'
+require_relative 'rubype/contract'
 require 'rubype/rubype'
 
 module Rubype
-  @@typed_method_info = Hash.new({})
   module TypeInfo; end
   Module.send(:include, TypeInfo)
   Symbol.send(:include, TypeInfo)
+  @@typed_method = Hash.new({})
+
   class << self
     def define_typed_method(owner, meth, type_info_hash, __rubype__)
       raise InvalidTypesigError unless valid_type_info_hash?(type_info_hash)
       arg_types, rtn_type = *type_info_hash.first
-
-      @@typed_method_info[owner][meth] = { arg_types => rtn_type }
-
+      contract = Contract.new(arg_types, rtn_type, owner, meth)
+      @@typed_method[owner][meth] = contract
       method_visibility = get_method_visibility(owner, meth)
       __rubype__.send(:define_method, meth) do |*args, &block|
-        caller_trace = caller_locations(1, 5)
-        ::Rubype.assert_args_type(self.class, meth, args, arg_types, caller_trace)
-        super(*args, &block).tap { |rtn| ::Rubype.assert_rtn_type(self.class, meth, rtn, rtn_type, caller_trace) }
+        contract.assert_arg_types(self, args)
+        super(*args, &block)
+          .tap { |rtn| contract.assert_rtn_type(self, rtn) }
       end
       __rubype__.send(method_visibility, meth)
     end
@@ -34,11 +34,12 @@ module Rubype
       end
     end
 
-    def typed_method_info
-      @@typed_method_info
+    def typed_method
+      @@typed_method
     end
 
     private
+
       def valid_type_info_hash?(type_info_hash)
         return false unless type_info_hash.is_a?(Hash)
         type_info_hash.first[0].is_a?(Array)

--- a/lib/rubype/contract.rb
+++ b/lib/rubype/contract.rb
@@ -1,59 +1,16 @@
 require_relative 'ordinalize'
+require 'rubype/rubype'
 
-class Rubype::ArgumentTypeError < ::TypeError; end
-class Rubype::ReturnTypeError   < ::TypeError; end
 class Rubype::Contract
   attr_accessor :arg_types, :rtn_type
   def initialize(arg_types, rtn_type, owner, meth)
-    @meth = meth
     @owner = owner
+    @meth = meth
     @arg_types = arg_types
     @rtn_type = rtn_type
-    @trace = caller_locations(1, 5)
   end
 
   def info
     { @arg_types => @rtn_type }
-  end
-
-  def assert_rtn_type(meth_caller, rtn)
-    return if match_type?(rtn, @rtn_type)
-    raise Rubype::ReturnTypeError,
-          error_mes("#{meth_caller.class}##{@meth}'s return", @rtn_type, rtn, @trace)
-  end
-
-  def assert_arg_types(meth_caller, args)
-    args.size.times do |i|
-      arg = args[i]
-      type = @arg_types[i]
-      next if match_type?(arg, type)
-      raise Rubype::ArgumentTypeError,
-            error_mes("#{meth_caller.class}##{@meth}'s #{ordinalize(i + 1)} argument", type, arg, @trace)
-    end
-  end
-
-  private
-  def error_mes(target, expected, actual, caller_trace)
-    <<-ERROR_MES
-for #{target}
-Expected: #{expected_mes(expected)},
-Actual:   #{actual.inspect}
-
-#{caller_trace.join("\n")}
-    ERROR_MES
-  end
-
-  def match_type?(obj, type_info)
-    case type_info
-    when Module then obj.is_a?(type_info)
-    when Symbol then obj.respond_to?(type_info)
-    end
-  end
-
-  def expected_mes(expected)
-    case expected
-    when Module then expected
-    when Symbol then "respond to :#{expected}"
-    end
   end
 end

--- a/lib/rubype/contract.rb
+++ b/lib/rubype/contract.rb
@@ -1,0 +1,59 @@
+require_relative 'ordinalize'
+
+class Rubype::ArgumentTypeError < ::TypeError; end
+class Rubype::ReturnTypeError   < ::TypeError; end
+class Rubype::Contract
+  attr_accessor :arg_types, :rtn_type
+  def initialize(arg_types, rtn_type, owner, meth)
+    @meth = meth
+    @owner = owner
+    @arg_types = arg_types
+    @rtn_type = rtn_type
+    @trace = caller_locations(1, 5)
+  end
+
+  def info
+    { @arg_types => @rtn_type }
+  end
+
+  def assert_rtn_type(meth_caller, rtn)
+    return if match_type?(rtn, @rtn_type)
+    raise Rubype::ReturnTypeError,
+          error_mes("#{meth_caller.class}##{@meth}'s return", @rtn_type, rtn, @trace)
+  end
+
+  def assert_arg_types(meth_caller, args)
+    args.size.times do |i|
+      arg = args[i]
+      type = @arg_types[i]
+      next if match_type?(arg, type)
+      raise Rubype::ArgumentTypeError,
+            error_mes("#{meth_caller.class}##{@meth}'s #{ordinalize(i + 1)} argument", type, arg, @trace)
+    end
+  end
+
+  private
+  def error_mes(target, expected, actual, caller_trace)
+    <<-ERROR_MES
+for #{target}
+Expected: #{expected_mes(expected)},
+Actual:   #{actual.inspect}
+
+#{caller_trace.join("\n")}
+    ERROR_MES
+  end
+
+  def match_type?(obj, type_info)
+    case type_info
+    when Module then obj.is_a?(type_info)
+    when Symbol then obj.respond_to?(type_info)
+    end
+  end
+
+  def expected_mes(expected)
+    case expected
+    when Module then expected
+    when Symbol then "respond to :#{expected}"
+    end
+  end
+end

--- a/lib/rubype/core_ext.rb
+++ b/lib/rubype/core_ext.rb
@@ -19,17 +19,17 @@ end
 
 class Method
   def type_info
-    Rubype.typed_method[owner][name].info
+    Rubype.typed_methods[owner][name].info
   end
   typesig :type_info, [] => Hash
 
   def arg_types
-    Rubype.typed_method[owner][name].arg_types
+    Rubype.typed_methods[owner][name].arg_types
   end
   typesig :arg_types, [] => Array
 
   def return_type
-    Rubype.typed_method[owner][name].rtn_type
+    Rubype.typed_methods[owner][name].rtn_type
   end
   typesig :arg_types, [] => Any
 end

--- a/lib/rubype/core_ext.rb
+++ b/lib/rubype/core_ext.rb
@@ -19,17 +19,17 @@ end
 
 class Method
   def type_info
-    Rubype.typed_method_info[owner][name]
+    Rubype.typed_method[owner][name].info
   end
   typesig :type_info, [] => Hash
 
   def arg_types
-    type_info.first.first if type_info
+    Rubype.typed_method[owner][name].arg_types
   end
   typesig :arg_types, [] => Array
 
   def return_type
-    type_info.first.last if type_info
+    Rubype.typed_method[owner][name].rtn_type
   end
   typesig :arg_types, [] => Any
 end


### PR DESCRIPTION
I was afraid to push it straight into develop. 
@gogotanaka, please review.

It helps to avoid passing ton of arguments to each method
Refactoring haven't affected performance:
````
Calculating -------------------------------------
      Contract class    15.258k i/100ms
        Plain Rubype    15.129k i/100ms
-------------------------------------------------
      Contract class    281.862k (± 4.6%) i/s -      1.419M
        Plain Rubype    278.688k (± 4.7%) i/s -      1.392M

Comparison:
      Contract class:   281861.6 i/s
        Plain Rubype:   278688.4 i/s - 1.01x slower

alculating -------------------------------------
      Contract class    15.258k i/100ms
        Plain Rubype    15.129k i/100ms
-------------------------------------------------
      Contract class    281.862k (± 4.6%) i/s -      1.419M
        Plain Rubype    278.688k (± 4.7%) i/s -      1.392M

Comparison:
      Contract class:   281861.6 i/s
        Plain Rubype:   278688.4 i/s - 1.01x slower
````